### PR TITLE
feat: pre-signed direct-upload intents + finalize endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A beautiful dark-themed web interface for managing files in Supabase Storage. Ea
 - [CLI Usage](#-cli-usage)
 - [Using as a Module](#-using-as-a-module)
 - [Configuration](#-configuration)
+- [Webhook Consumer Guide](#-webhook-consumer-guide)
 - [Troubleshooting](#-troubleshooting)
 - [Security](#-security)
 - [Tech Stack](#-tech-stack)
@@ -219,6 +220,10 @@ SIGNED_URL_TTL_DEFAULT=60
 SIGNED_URL_TTL_MIN=30
 SIGNED_URL_TTL_MAX=300
 SIGNED_URL_ALLOWED_PREFIXES=*
+
+# Direct upload mode
+DIRECT_UPLOAD_MAX_BYTES=104857600
+DIRECT_UPLOAD_ALLOWED_MIME_REGEX=
 ```
 
 ## 🔌 API Notes (Signed URL Retrieval)
@@ -243,6 +248,7 @@ Returns a short-lived signed URL for an object.
 
 Now issues a short-lived signed URL and redirects to Supabase Storage (instead of proxy-streaming through the app server). The same TTL and scope policies are enforced.
 
+<<<<<<< HEAD
 ## 🔁 Resumable Upload API (MVP)
 
 This MVP exposes a server-managed resumable session API (sequential chunk upload).
@@ -306,6 +312,14 @@ Server validates completeness (`uploadedBytes === totalSize`), optionally valida
 3. On network failure/timeouts, fetch session state (`GET append`) and resume from `nextOffset`.
 4. Call complete when all bytes are uploaded.
 
+## 🚀 Direct Upload API
+
+### `POST /api/upload/intents`
+Creates an upload intent and returns a pre-signed upload payload.
+
+### `POST /api/upload/finalize`
+Finalizes an uploaded object with ownership/scope checks and idempotency via `Idempotency-Key`.
+
 ## 🔧 Troubleshooting
 
 **"Authentication required"**
@@ -336,6 +350,17 @@ Server validates completeness (`uploadedBytes === totalSize`), optionally valida
 - ✅ **Security Headers** - CSP, X-Frame-Options, and more
 
 See `SECURITY.md` for detailed security documentation.
+
+### Baseline controls (Issue #22)
+
+- **RBAC:** `admin` / `operator` / `read-only`
+- **Quotas:** request, bandwidth, and storage baseline enforcement hooks
+- **Audit trail:** append-only hash-chained event log + `GET /api/audit` query endpoint
+
+Configure via `env.example`:
+`RBAC_ADMIN_EMAILS`, `RBAC_OPERATOR_EMAILS`, `QUOTA_REQUEST_WINDOW_MS`,
+`QUOTA_MAX_REQUESTS_PER_WINDOW`, `QUOTA_MAX_BANDWIDTH_BYTES_PER_WINDOW`,
+`QUOTA_MAX_STORAGE_BYTES`, `AUDIT_LOG_FILE`.
 
 ## 🛠️ Tech Stack
 

--- a/env.example
+++ b/env.example
@@ -76,3 +76,13 @@ SIGNED_URL_ALLOWED_PREFIXES=*
 # Enable emoji in CLI output (optional, defaults to 'true')
 # Set to 'false' to disable emoji in console output
 ENABLE_EMOJI=true
+
+# =============================================================================
+# WEBHOOK / EVENT PIPELINE (Optional)
+# =============================================================================
+# Emits upload.started / upload.completed / upload.failed to your consumer.
+WEBHOOK_URL=https://your-consumer.example.com/webhooks/uploads
+WEBHOOK_SECRET=replace-with-a-long-random-secret
+WEBHOOK_MAX_RETRIES=3
+WEBHOOK_TIMEOUT_MS=10000
+WEBHOOK_BASE_DELAY_MS=500

--- a/pages/api/upload/finalize.js
+++ b/pages/api/upload/finalize.js
@@ -1,0 +1,42 @@
+import { validateMethod, sendError, sendSuccess } from '../../../utils/apiHelpers';
+import { withAuth } from '../../../utils/authMiddleware.js';
+import { createStorageClientWithErrorHandling } from '../../../utils/storageClientFactory.js';
+import { assertScopedObjectKey, getIntentRecord, commitIntentRecord, getIdempotentCommit, setIdempotentCommit, verifyObjectExists } from '../../../utils/directUpload.mjs';
+
+async function handler(req, res) {
+  if (!validateMethod(req, res, 'POST')) return;
+  const storageResult = await createStorageClientWithErrorHandling(req, res);
+  if (!storageResult) return;
+  const { client: supabase } = storageResult;
+
+  const idempotencyKey = req.headers['idempotency-key'];
+  if (!idempotencyKey || typeof idempotencyKey !== 'string') return sendError(res, 'Idempotency-Key header is required', 400);
+
+  const cached = getIdempotentCommit(req.user.id, idempotencyKey);
+  if (cached) return sendSuccess(res, cached);
+
+  try {
+    const { intentId, bucket, objectKey } = req.body || {};
+    if (!intentId || !bucket || !objectKey) return sendError(res, 'intentId, bucket, and objectKey are required', 400);
+
+    const intent = getIntentRecord(intentId);
+    if (!intent) return sendError(res, 'Intent not found or expired', 404);
+    if (intent.userId !== req.user.id) return sendError(res, 'Intent does not belong to this user', 403);
+
+    assertScopedObjectKey(req.user, objectKey);
+    if (intent.bucket !== bucket || intent.objectKey !== objectKey) return sendError(res, 'Finalize payload does not match intent', 400);
+
+    const found = await verifyObjectExists(supabase, bucket, objectKey);
+    if (!found) return sendError(res, 'Uploaded object not found', 404);
+
+    commitIntentRecord(intentId);
+    const response = { intentId, bucket, objectKey, committedAt: new Date().toISOString(), size: found.metadata?.size || null, etag: found.metadata?.eTag || null };
+    setIdempotentCommit(req.user.id, idempotencyKey, response);
+    return sendSuccess(res, response);
+  } catch (error) {
+    if (error.message?.includes('outside allowed scope')) return sendError(res, error.message, 403);
+    return sendError(res, error.message || 'Failed to finalize upload', 500);
+  }
+}
+
+export default withAuth(handler);

--- a/pages/api/upload/intents.js
+++ b/pages/api/upload/intents.js
@@ -1,0 +1,41 @@
+import { validateMethod, sendError, sendSuccess } from '../../../utils/apiHelpers';
+import { withAuth } from '../../../utils/authMiddleware.js';
+import { createStorageClientWithErrorHandling } from '../../../utils/storageClientFactory.js';
+import { normalizeScopedObjectKey, createIntentRecord } from '../../../utils/directUpload.mjs';
+
+const DEFAULT_MAX_BYTES = 100 * 1024 * 1024;
+
+async function handler(req, res) {
+  if (!validateMethod(req, res, 'POST')) return;
+  const storageResult = await createStorageClientWithErrorHandling(req, res);
+  if (!storageResult) return;
+  const { client: supabase, settings } = storageResult;
+
+  try {
+    const { bucket, objectKey, filename, contentType, contentLength } = req.body || {};
+    const bucketName = bucket || settings.default_bucket || 'files';
+    const maxBytes = Number(process.env.DIRECT_UPLOAD_MAX_BYTES || DEFAULT_MAX_BYTES);
+    if (!contentLength || Number(contentLength) <= 0) return sendError(res, 'contentLength is required', 400);
+    if (Number(contentLength) > maxBytes) return sendError(res, `contentLength exceeds maximum (${maxBytes})`, 400);
+
+    const { objectKey: scopedObjectKey, prefix } = normalizeScopedObjectKey(req.user, objectKey, filename);
+    const allowedMimeRegex = process.env.DIRECT_UPLOAD_ALLOWED_MIME_REGEX || '.*';
+    if (contentType && !(new RegExp(allowedMimeRegex)).test(contentType)) return sendError(res, 'contentType is not allowed', 400);
+
+    const intent = createIntentRecord({
+      userId: req.user.id,
+      bucket: bucketName,
+      objectKey: scopedObjectKey,
+      constraints: { maxBytes, contentLength: Number(contentLength), contentType: contentType || 'application/octet-stream', allowedMimeRegex },
+    });
+
+    const { data, error } = await supabase.storage.from(bucketName).createSignedUploadUrl(scopedObjectKey);
+    if (error) return sendError(res, error.message || 'Failed to create signed upload url', 500);
+
+    return sendSuccess(res, { intent: { intentId: intent.intentId, bucket: bucketName, objectKey: scopedObjectKey, prefix, expiresAt: new Date(intent.expiresAt).toISOString(), constraints: intent.constraints }, upload: data }, 201);
+  } catch (error) {
+    return sendError(res, error.message || 'Failed to create upload intent', 500);
+  }
+}
+
+export default withAuth(handler);

--- a/tests/direct-upload.test.mjs
+++ b/tests/direct-upload.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeScopedObjectKey, createIntentRecord, getIntentRecord, setIdempotentCommit, getIdempotentCommit, __resetDirectUploadStoresForTests } from '../utils/directUpload.mjs';
+
+const user = { id: 'user-123', app_metadata: { tenant_id: 'tenant-abc' } };
+
+test.beforeEach(() => __resetDirectUploadStoresForTests());
+
+test('happy path: normalizes scoped key and stores intent', () => {
+  const { objectKey, prefix } = normalizeScopedObjectKey(user, 'docs/readme.md', 'readme.md');
+  assert.equal(prefix, 'tenants/tenant-abc/users/user-123/');
+  assert.equal(objectKey, 'tenants/tenant-abc/users/user-123/docs/readme.md');
+  const intent = createIntentRecord({ userId: user.id, bucket: 'files', objectKey, constraints: { contentLength: 1024 } });
+  assert.equal(getIntentRecord(intent.intentId)?.bucket, 'files');
+});
+
+test('invalid scope: rejects traversal-style key', () => {
+  assert.throws(() => normalizeScopedObjectKey(user, '../secrets.txt', 'secrets.txt'), /Invalid object key/);
+});
+
+test('replay/idempotency: same key returns same cached response', () => {
+  const response = { intentId: 'intent-1', bucket: 'files', objectKey: 'tenants/tenant-abc/users/user-123/docs/readme.md' };
+  setIdempotentCommit(user.id, 'idem-001', response);
+  assert.deepEqual(getIdempotentCommit(user.id, 'idem-001'), response);
+});

--- a/utils/directUpload.mjs
+++ b/utils/directUpload.mjs
@@ -1,0 +1,71 @@
+import crypto from 'crypto';
+const DEFAULT_TTL_MS = 15 * 60 * 1000;
+const intentStore = new Map();
+const idempotencyStore = new Map();
+
+export function resolveTenantId(user) { return user?.app_metadata?.tenant_id || user?.user_metadata?.tenant_id || 'default'; }
+export function buildScopedPrefix(user) { return `tenants/${resolveTenantId(user)}/users/${user.id}/`; }
+
+function sanitizeSegment(value, fallback = 'file') {
+  return String(value || fallback).trim().replace(/[^a-zA-Z0-9._-]/g, '-').replace(/-+/g, '-').replace(/^[-.]+|[-.]+$/g, '') || fallback;
+}
+
+export function normalizeScopedObjectKey(user, objectKey, filename = 'upload.bin') {
+  const prefix = buildScopedPrefix(user);
+  let scoped = String(objectKey || '').replace(/^\/+/, '');
+  if (!scoped) scoped = `${Date.now()}-${sanitizeSegment(filename, 'upload.bin')}`;
+  if (scoped.includes('..') || scoped.includes('\\')) throw new Error('Invalid object key');
+  if (!scoped.startsWith(prefix)) scoped = `${prefix}${scoped}`;
+  if (!scoped.startsWith(prefix)) throw new Error('Object key must be inside scoped prefix');
+  return { objectKey: scoped, prefix };
+}
+
+export function assertScopedObjectKey(user, objectKey) {
+  const prefix = buildScopedPrefix(user);
+  if (!String(objectKey || '').startsWith(prefix)) throw new Error('Object key outside allowed scope');
+  return prefix;
+}
+
+export function createIntentRecord({ userId, bucket, objectKey, constraints, ttlMs = DEFAULT_TTL_MS }) {
+  const now = Date.now();
+  const intent = { intentId: crypto.randomUUID(), userId, bucket, objectKey, constraints, state: 'pending', createdAt: now, expiresAt: now + ttlMs };
+  intentStore.set(intent.intentId, intent);
+  return intent;
+}
+
+export function getIntentRecord(intentId) {
+  const intent = intentStore.get(intentId);
+  if (!intent) return null;
+  if (intent.expiresAt <= Date.now()) { intentStore.delete(intentId); return null; }
+  return intent;
+}
+
+export function commitIntentRecord(intentId) {
+  const intent = getIntentRecord(intentId);
+  if (!intent) throw new Error('Intent not found or expired');
+  if (intent.state !== 'committed') { intent.state = 'committed'; intent.committedAt = Date.now(); intentStore.set(intentId, intent); }
+  return intent;
+}
+
+export function getIdempotentCommit(userId, idempotencyKey) {
+  const key = `${userId}:${idempotencyKey}`;
+  const entry = idempotencyStore.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt <= Date.now()) { idempotencyStore.delete(key); return null; }
+  return entry.response;
+}
+
+export function setIdempotentCommit(userId, idempotencyKey, response, ttlMs = DEFAULT_TTL_MS) {
+  idempotencyStore.set(`${userId}:${idempotencyKey}`, { response, expiresAt: Date.now() + ttlMs });
+}
+
+export async function verifyObjectExists(supabase, bucket, objectKey) {
+  const parts = objectKey.split('/');
+  const fileName = parts.pop();
+  const folder = parts.join('/');
+  const { data, error } = await supabase.storage.from(bucket).list(folder, { search: fileName, limit: 100 });
+  if (error) throw new Error(error.message || 'Failed to verify uploaded object');
+  return (data || []).find((item) => item.name === fileName) || null;
+}
+
+export function __resetDirectUploadStoresForTests() { intentStore.clear(); idempotencyStore.clear(); }


### PR DESCRIPTION
## Summary
- add  to mint direct-upload intents and signed upload urls
- enforce tenant/user scoped object key prefix policy
- add  with intent validation + idempotency key replay protection
- add unit tests for happy path, invalid scope, and idempotent replay
- document direct upload API and env flags

## Validation
- 
> supabase-file-manager@1.0.0 test
> node --test tests/*.test.mjs

✔ happy path: normalizes scoped key and stores intent (0.827ms)
✔ invalid scope: rejects traversal-style key (0.20025ms)
✔ replay/idempotency: same key returns same cached response (0.554875ms)
✔ signature roundtrip works and rejects tampered payload (0.826375ms)
✔ webhook retries and succeeds (5.417625ms)
✔ webhook retry exhausted path logs error (0.364709ms)
✔ complete/finalize enforces file type validation (blocked extension) (3.463167ms)
✔ append request rejects oversize payload early via content-length (0.245375ms)
✔ append request rejects oversize payload during streaming (0.158875ms)
✔ concurrent appends are serialized and offset check/write is atomic (1.1465ms)
ℹ Error: Test "complete/finalize enforces file type validation (blocked extension)" at tests/resumable-sessions.test.mjs:25:1 generated asynchronous activity after the test ended. This activity created the error "Error: File type .exe is not allowed for security reasons" and would have caused the test to fail, but instead triggered an unhandledRejection event.
ℹ Error: Test "concurrent appends are serialized and offset check/write is atomic" at tests/resumable-sessions.test.mjs:64:1 generated asynchronous activity after the test ended. This activity created the error "Error: Offset mismatch" and would have caused the test to fail, but instead triggered an unhandledRejection event.
✖ tests/resumable-sessions.test.mjs (64.046166ms)
ℹ tests 11
ℹ suites 0
ℹ pass 10
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 69.875458

✖ failing tests:

test at tests/resumable-sessions.test.mjs:1:1
✖ tests/resumable-sessions.test.mjs (64.046166ms)
  'test failed'
- 
> supabase-file-manager@1.0.0 build
> next build

  ▲ Next.js 14.2.35

   Linting and checking validity of types ...